### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ function getPath (path) {
 function getProp (obj = {}, path = [], defaultValue = undefined, validate = (x) => x === x) {
   const pathArray = getPath(path)
   const key = pathArray.pop()
+
+  if (isPrototypePolluted(key))
+    return
+
   console.log(path, pathArray, key)
   try {
     if (path.length === 0 || pathArray.length === 0) {
@@ -38,7 +42,7 @@ function setProp (obj, prop, val, createIfNotExists = true) {
 
   const ref = (createIfNotExists)
     ? path.reduce((c, i) => {
-      if (!c[i] || typeof c[i] !== 'object' || Array.isArray(c[i])) {
+      if (!c[i] || typeof c[i] !== 'object' || Array.isArray(c[i]) || isPrototypePolluted(i)) {
         c[i] = {}
       }
       return c[i]
@@ -79,6 +83,10 @@ function has (obj, path) {
 
 function clone (obj) {
   return JSON.parse(JSON.stringify(obj))
+}
+
+function isPrototypePolluted(key) {
+  return ['__proto__', 'constructor', 'prototype'].includes(key)
 }
 
 module.exports = { get: getProp, set: setProp, has, delete: deleteProp, clone }


### PR DESCRIPTION
### :bar_chart: Metadata *

`obj-helpers` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-obj-helpers

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var objHelpers = require("obj-helpers")
var obj = {}
console.log("Before : " + {}.polluted);
objHelpers.set(obj,"__proto__.polluted","Yes! Its Polluted");
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i obj-helpers # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/107624632-2eff5b00-6c81-11eb-8cca-3e898829d354.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
